### PR TITLE
Update ProfileResources_de.properties

### DIFF
--- a/ingrid-portal-apps/src/webapp/profiles/krzn/ingrid-portal-apps/WEB-INF/classes/de/ingrid/portal/resources/ProfileResources_de.properties
+++ b/ingrid-portal-apps/src/webapp/profiles/krzn/ingrid-portal-apps/WEB-INF/classes/de/ingrid/portal/resources/ProfileResources_de.properties
@@ -1,6 +1,6 @@
 #AdminPortalResources
-account.create.confirmation.email.subject=Geodatenkatalog Niederrhein: Für Sie wurde ein Account angelegt
-account.edit.confirmation.email.subject=Geodatenkatalog Niederrhein: Ihr Account wurde geändert
+account.create.confirmation.email.subject=Geodatenkatalog Niederrhein: FÃ¼r Sie wurde ein Account angelegt
+account.edit.confirmation.email.subject=Geodatenkatalog Niederrhein: Ihr Account wurde geÃ¤ndert
 password.forgotten.email.subject=Geodatenkatalog Niederrhein: Ihre Anfrage
 
 #CommonResources
@@ -17,10 +17,10 @@ common.result.counter.ranked.grouped=<h3>{0} Ergebnisse</h3>
 teaser.ingridInform.title=<span style="text-transform:none">Geodatenkatalog Niederrhein INFORMIERT</span>
 sitemap.title=Inhalt
 sitemap.content.overview=Inhalt
-sitemap.area.main.measures.description=Stöbern Sie in aktuellen Messwerten angeschlossener Messnetze.
+sitemap.area.main.measures.description=StÃ¶bern Sie in aktuellen Messwerten angeschlossener Messnetze.
 sitemap.area.main.search.catalogs.description=Durchsuchen Sie unsere Datenkataloge.
 sitemap.area.main.maps.description=Betrachten Sie Internetkarten zu umweltrelevanten Themen verschiedener Anbieter.
-sitemap.area.main.about=Über Geodatenkatalog Niederrhein
+sitemap.area.main.about=Ãœber Geodatenkatalog Niederrhein
 sitemap.area.main.about.description=Informationen zum Geodatenkatalog Niederrhein-Portal.
 sitemap.area.main.about.tooltip=Hintergrundinformationen zu Geodatenkatalog Niederrhein-Portal
 sitemap.area.main.portrait.description=Informationen zum Hintergrund des Portalangebots.
@@ -28,10 +28,10 @@ sitemap.area.main.provider.tooltip=Liste der Anbieter von Geodatenkatalog Nieder
 sitemap.area.main.provider=Anbieter
 sitemap.area.main.provider.description=Unsere Partner und Informationsanbieter.
 sitemap.area.service.myportal=Mein Geodatenkatalog Niederrhein
-sitemap.area.service.myportal.description=Ihre persönlichen Einstellungen.
+sitemap.area.service.myportal.description=Ihre persÃ¶nlichen Einstellungen.
 sitemap.area.service.sitemap=Inhalt
 sitemap.area.service.help.description=Zur Online-Hilfe.
-sitemap.area.footer.disclaimer.description=Verantwortliche und Zuständigkeiten.
+sitemap.area.footer.disclaimer.description=Verantwortliche und ZustÃ¤ndigkeiten.
 
 #SearchSimpleResources
 searchSimple.title.search=Suche
@@ -39,10 +39,10 @@ searchSimple.query.search=Suche
 searchSimple.query.submit=Suche
 searchSimple.portlet.title.1=
 searchSimple.portlet.title.2=Metadaten
-searchSimple.portlet.title.3=zu Geodaten, Webdiensten und Geofachportalen<br>der Stadt Krefeld sowie der Kreise Kleve, Viersen und Wesel
+searchSimple.portlet.title.3=zu Geodaten, Webdiensten und Geofachportalen<br>der StÃ¤dte Bottrop und Krefeld sowie<br>der Kreise Kleve, Viersen und Wesel
 
 #SearchDetailResources
-search.detail.back=Zurück zum Geodatenkatalog Niederrhein
+search.detail.back=ZurÃ¼ck zum Geodatenkatalog Niederrhein
 search.detail.portal.institution=Geodatenkatalog Niederrhein
 t01_object.polygon_wkt=Begrenzungspolygon im WKT Format (in WGS84)
 t011_obj_serv.environment=Produktionsumgebung


### PR DESCRIPTION
Aktualisierung der Portalseite des Geodatenkatalog Niederrhein: Aufnahme der Stadt Bottrop in den Text.
Siehe Zeile 42.